### PR TITLE
Empty String Bug Repro

### DIFF
--- a/vellum_test.go
+++ b/vellum_test.go
@@ -298,7 +298,7 @@ func TestRoundTripEmptyString(t *testing.T) {
 		t.Fatalf("error creating builder: %v", err)
 	}
 
-	err = b.Insert([]byte(""), 0)
+	err = b.Insert([]byte(""), 1)
 	if err != nil {
 		t.Fatalf("error inserting empty string")
 	}
@@ -325,7 +325,7 @@ func TestRoundTripEmptyString(t *testing.T) {
 
 	// first check all the expected values
 	want := map[string]uint64{
-		"": 0,
+		"": 1,
 	}
 	got := map[string]uint64{}
 	itr, err := fst.Iterator(nil, nil)


### PR DESCRIPTION
Found a bug in how FST's with a single nil element are handled. The unit test testing this case had the value for the nil key set to 0, setting it any non-zero value breaks. 