### PR TITLE
Re-work pooling to have a fixed memory cost

### DIFF
--- a/builder_test.go
+++ b/builder_test.go
@@ -177,13 +177,13 @@ func TestBuilderNodeEquiv(t *testing.T) {
 			"both states final, same transitions, but different trans val",
 			&builderNode{
 				final: true,
-				trans: []*transition{
+				trans: []transition{
 					{in: 'a', out: 7},
 				},
 			},
 			&builderNode{
 				final: true,
-				trans: []*transition{
+				trans: []transition{
 					{in: 'a', out: 9},
 				},
 			},

--- a/encoder_v1_test.go
+++ b/encoder_v1_test.go
@@ -59,7 +59,7 @@ func TestEncoderStart(t *testing.T) {
 func TestEncoderStateOneNextWithCommonInput(t *testing.T) {
 
 	curr := &builderNode{
-		trans: []*transition{
+		trans: []transition{
 			{
 				in:   'a',
 				addr: 27,
@@ -95,7 +95,7 @@ func TestEncoderStateOneNextWithCommonInput(t *testing.T) {
 func TestEncoderStateOneNextWithUncommonInput(t *testing.T) {
 
 	curr := &builderNode{
-		trans: []*transition{
+		trans: []transition{
 			{
 				in:   0xff,
 				addr: 27,
@@ -132,7 +132,7 @@ func TestEncoderStateOneNextWithUncommonInput(t *testing.T) {
 func TestEncoderStateOneNotNextWithCommonInputNoValue(t *testing.T) {
 
 	curr := &builderNode{
-		trans: []*transition{
+		trans: []transition{
 			{
 				in:   'a',
 				addr: 32,
@@ -173,7 +173,7 @@ func TestEncoderStateOneNotNextWithCommonInputNoValue(t *testing.T) {
 func TestEncoderStateOneNotNextWithUncommonInputNoValue(t *testing.T) {
 
 	curr := &builderNode{
-		trans: []*transition{
+		trans: []transition{
 			{
 				in:   0xff,
 				addr: 32,
@@ -215,7 +215,7 @@ func TestEncoderStateOneNotNextWithUncommonInputNoValue(t *testing.T) {
 func TestEncoderStateOneNotNextWithCommonInputWithValue(t *testing.T) {
 
 	curr := &builderNode{
-		trans: []*transition{
+		trans: []transition{
 			{
 				in:   'a',
 				addr: 32,
@@ -258,7 +258,7 @@ func TestEncoderStateOneNotNextWithCommonInputWithValue(t *testing.T) {
 func TestEncoderStateOneNotNextWithUncommonInputWithValue(t *testing.T) {
 
 	curr := &builderNode{
-		trans: []*transition{
+		trans: []transition{
 			{
 				in:   0xff,
 				addr: 32,
@@ -302,7 +302,7 @@ func TestEncoderStateOneNotNextWithUncommonInputWithValue(t *testing.T) {
 func TestEncoderStateManyWithNoValues(t *testing.T) {
 
 	curr := &builderNode{
-		trans: []*transition{
+		trans: []transition{
 			{
 				in:   'a',
 				addr: 32,
@@ -356,7 +356,7 @@ func TestEncoderStateManyWithNoValues(t *testing.T) {
 func TestEncoderStateManyWithValues(t *testing.T) {
 
 	curr := &builderNode{
-		trans: []*transition{
+		trans: []transition{
 			{
 				in:   'a',
 				addr: 32,
@@ -424,10 +424,10 @@ func TestEncoderStateMoreTransitionsThanFitInHeader(t *testing.T) {
 func testEncoderStateNTransitions(t *testing.T, n int) {
 
 	curr := &builderNode{
-		trans: make([]*transition, n),
+		trans: make([]transition, n),
 	}
 	for i := 0; i < n; i++ {
-		curr.trans[i] = &transition{
+		curr.trans[i] = transition{
 			in:   byte(i),
 			addr: 32,
 		}

--- a/registry_test.go
+++ b/registry_test.go
@@ -19,10 +19,11 @@ import "testing"
 // FIXME add tests for MRU
 
 func TestRegistry(t *testing.T) {
-	r := newRegistry(10, 1)
+	p := &builderNodePool{}
+	r := newRegistry(p, 10, 1)
 
 	n1 := &builderNode{
-		trans: []*transition{
+		trans: []transition{
 			{
 				in:   'a',
 				addr: 1,


### PR DESCRIPTION
Earlier versions of pooling didn't re-use allocations within the construction of a FST. It only amortised allocations across different FSTs being built. As a result of this, its memory usage grew proportional to the number of distinct states in the FST (this can be several gigabytes when constructing large FSTs)

To address this shortcoming, this PR relies on the fact that frozen builderNode(s) can be re-used once they're evicted from the `Registry`. A further nice property of this PR's implementation is it bounds memory usage to be proportional to the size of the `Registry` (plus max length of `unfinishedNodes`). This allows users of Vellum to control memory behaviour more predictably, and seems to give a nice 20% CPU savings too. 

### Some stats from a micro-benchmark I've been using: 

Before the PR (i.e. `master`) - time **42s**, max total memory: **8.6GB**
```
time ./vellum-upstream-master --expvar ':8081' set --sorted sample.input output.fst
./vellum-upstream-master --expvar ':8081' set --sorted sample.input output.fs  54.00s user 5.74s system 140% cpu 42.449 total
```

<img width="1411" alt="upstream-master" src="https://user-images.githubusercontent.com/199982/44627645-e176c280-a94e-11e8-8500-66a739db5e81.png">

After PR: time **33s**, max total memory: **23MB**
```
time ./vellum-custom-pooling --expvar ':8081' set --sorted sample.input output.fst
./vellum-custom-pooling --expvar ':8081' set --sorted sample.input output.fst  47.51s user 1.19s system 146% cpu 33.132 total
```

<img width="1382" alt="reworked-pooling" src="https://user-images.githubusercontent.com/199982/44627651-f3586580-a94e-11e8-8f7b-3d18ec4f54c7.png">
