### PR TITLE
Improve BuilderNode pooling significantly and add better comments / documentation

### DIFF
--- a/builder.go
+++ b/builder.go
@@ -24,6 +24,13 @@ var defaultBuilderOpts = &BuilderOpts{
 	RegistryTableSize: 1000,
 	RegistryMRUSize:   2,
 	BuilderNodePoolingConfig: BuilderNodePoolingConfig{
+		// This value should always be significantly larger than
+		// RegistryTableSize * RegistryMRUSize because that defines
+		// how many items can be stored in the registry, and if the
+		// pools MaxSize is not much larger than that, then all the
+		// BuilderNodes will end up stuck in the registry and not
+		// returned to the pool which will cause the building process
+		// to begin allocating a lot.
 		MaxSize:           10000,
 		MaxTransitionSize: 32,
 	},

--- a/builder.go
+++ b/builder.go
@@ -479,8 +479,6 @@ func (p *builderNodePool) Get() *builderNode {
 	return head
 }
 
-var counter = 0
-
 func (p *builderNodePool) Put(v *builderNode) {
 	if v == nil ||
 		p.size >= p.config.MaxSize ||

--- a/builder.go
+++ b/builder.go
@@ -162,14 +162,22 @@ func (b *Builder) compileFrom(iState int) error {
 func (b *Builder) compile(node *builderNode) (int, error) {
 	if node.final && len(node.trans) == 0 &&
 		node.finalOutput == 0 {
+		// We're done with this node so its safe to put it back in the pool.
 		b.builderNodePool.Put(node)
 		return 0, nil
 	}
 	found, addr, entry := b.registry.entry(node)
 	if found {
+		// This node already existed in the registry (and thus the registry
+		// did not assume ownership of it) so its safe to put it back in
+		// the pool.
 		b.builderNodePool.Put(node)
 		return addr, nil
 	}
+	// If the node was not found in the registry, then the registry will
+	// have assumed ownership of it and is responsible for returning it
+	// to the pool.
+
 	addr, err := b.encoder.encodeState(node, b.lastAddr)
 	if err != nil {
 		return 0, err

--- a/builder.go
+++ b/builder.go
@@ -446,17 +446,14 @@ type BuilderNodePoolingConfig struct {
 
 // builderNodePool pools builderNodes using a singly linked list.
 //
-// NB: builderNode lifecylce is described by the following interactions -
-// +------------------------+                            +----------------------+
-// |    Unfinished Nodes    |      Transfer once         |        Registry      |
-// |(not frozen builderNode)|-----builderNode is ------->| (frozen builderNode) |
-// +------------------------+      marked frozen         +----------------------+
-//              ^                                                     |
-//              |                                                     |
-//              |                                                   Put()
-//              | Get() on        +-------------------+             when
-//              +-new char--------| builderNode Pool  |<-----------evicted
-//                                +-------------------+
+// The lifecycle is as follows:
+//
+// 1. Builder retrieves a node from the pool using Get() whenever it needs one.
+// 2. After a node is compiled it is either:
+//     a. Discarded and immediately returned to the pool.
+//     b. Transferred to the registry (which assumes ownership of it) and will
+//        return it to the pool when it evicts the node to make room for another,
+//        or when the entire registry is Reset().
 type builderNodePool struct {
 	config BuilderNodePoolingConfig
 	size   int

--- a/builder.go
+++ b/builder.go
@@ -21,7 +21,7 @@ import (
 
 var defaultBuilderOpts = &BuilderOpts{
 	Encoder:           1,
-	RegistryTableSize: 1000,
+	RegistryTableSize: 10000,
 	RegistryMRUSize:   2,
 	BuilderNodePoolingConfig: BuilderNodePoolingConfig{
 		// This value should always be significantly larger than
@@ -31,7 +31,7 @@ var defaultBuilderOpts = &BuilderOpts{
 		// BuilderNodes will end up stuck in the registry and not
 		// returned to the pool which will cause the building process
 		// to begin allocating a lot.
-		MaxSize:           10000,
+		MaxSize:           100000,
 		MaxTransitionSize: 32,
 	},
 }

--- a/builder.go
+++ b/builder.go
@@ -441,9 +441,10 @@ func outputCat(l, r uint64) uint64 {
 
 // BuilderNodePoolingConfig is the configuration struct for the BuilderNodePool.
 // Note that unsafe.SizeOf(transition{}) is 24 bytes and unsafe.SizeOf(BuilderNode{})
-// is 48 bytes so the amount of memory used by the pool should be approximately
+// is 48 bytes so the maximum amount of memory used by the pool should be approximately
 // MaxSize * (48 + 24 * MaxTransitionSize) not including the extra space required
-// by the G.C.
+// by the G.C. Note if an F.S.T construction never requires this many BuilderNodes then
+// the maximum size of the pool will never be reached as it is allocated lazily.
 type BuilderNodePoolingConfig struct {
 	// Maximum number of builder nodes can be retained in the pool.
 	MaxSize int

--- a/builder.go
+++ b/builder.go
@@ -21,11 +21,11 @@ import (
 
 var defaultBuilderOpts = &BuilderOpts{
 	Encoder:           1,
-	RegistryTableSize: 10000,
+	RegistryTableSize: 1000,
 	RegistryMRUSize:   2,
 	BuilderNodePoolingConfig: BuilderNodePoolingConfig{
 		MaxSize:           10000,
-		MaxTransitionSize: 100,
+		MaxTransitionSize: 32,
 	},
 }
 
@@ -469,9 +469,7 @@ func newBuilderNodePool(config BuilderNodePoolingConfig) *builderNodePool {
 
 func (p *builderNodePool) Get() *builderNode {
 	if p.head == nil {
-		return &builderNode{
-			trans: make([]transition, 0, 10),
-		}
+		return &builderNode{}
 	}
 	head := p.head
 	p.head = p.head.next

--- a/builder.go
+++ b/builder.go
@@ -142,30 +142,22 @@ func (b *Builder) Close() error {
 
 func (b *Builder) compileFrom(iState int) error {
 	addr := noneAddr
-	// var lastNode *builderNode
 	for iState+1 < len(b.unfinished.stack) {
-		// b.builderNodePool.Put(lastNode)
 		var node *builderNode
 		if addr == noneAddr {
 			node = b.unfinished.popEmpty()
-			// returnToPool = true
 		} else {
 			node = b.unfinished.popFreeze(addr)
-			// returnToPool = true
 		}
 		var err error
 		addr, err = b.compile(node)
 		if err != nil {
 			return nil
 		}
-		// lastNode = node
 	}
 	b.unfinished.topLastFreeze(addr)
-	// b.builderNodePool.Put(lastNode)
 	return nil
 }
-
-var finalCount = 0
 
 func (b *Builder) compile(node *builderNode) (int, error) {
 	if node.final && len(node.trans) == 0 &&
@@ -274,10 +266,7 @@ func (u *unfinishedNodes) pushEmpty(final bool) {
 	u.stack = append(u.stack, next)
 }
 
-var popRootCount = 0
-
 func (u *unfinishedNodes) popRoot() *builderNode {
-	popRootCount++
 	l := len(u.stack)
 	var unfinished *builderNodeUnfinished
 	u.stack, unfinished = u.stack[:l-1], u.stack[l-1]

--- a/builder_test.go
+++ b/builder_test.go
@@ -243,7 +243,12 @@ func BenchmarkBuilder(b *testing.B) {
 		b.Fatalf("error creating builder: %v", err)
 	}
 	for i := 0; i < b.N; i++ {
-		builder.Reset(ioutil.Discard)
+		err = builder.Reset(ioutil.Discard)
+		if err != nil {
+			if err != nil {
+				b.Fatalf("error reseting builder: %v", err)
+			}
+		}
 		err = insertStrings(builder, dataset, randomThousandVals)
 		if err != nil {
 			b.Fatalf("error inserting thousand words: %v", err)

--- a/builder_test.go
+++ b/builder_test.go
@@ -234,6 +234,9 @@ func loadWords(path string) ([]string, error) {
 var thousandTestWords []string
 
 func BenchmarkBuilder(b *testing.B) {
+	//fmt.Println(unsafe.Sizeof(builderNode{}))
+	// fmt.Println(unsafe.Sizeof(transition{}))
+	// panic("hmm")
 	dataset := thousandTestWords
 	randomThousandVals := randomValues(dataset)
 

--- a/builder_test.go
+++ b/builder_test.go
@@ -66,6 +66,7 @@ func TestBuilderSimple(t *testing.T) {
 	if err != nil {
 		t.Errorf("got error closing set builder: %v", err)
 	}
+	b.Reset(ioutil.Discard)
 }
 
 func TestBuilderSharedPrefix(t *testing.T) {
@@ -238,12 +239,12 @@ func BenchmarkBuilder(b *testing.B) {
 
 	b.ResetTimer()
 
+	builder, err := New(ioutil.Discard, nil)
+	if err != nil {
+		b.Fatalf("error creating builder: %v", err)
+	}
 	for i := 0; i < b.N; i++ {
-
-		builder, err := New(ioutil.Discard, nil)
-		if err != nil {
-			b.Fatalf("error creating builder: %v", err)
-		}
+		builder.Reset(ioutil.Discard)
 		err = insertStrings(builder, dataset, randomThousandVals)
 		if err != nil {
 			b.Fatalf("error inserting thousand words: %v", err)

--- a/builder_test.go
+++ b/builder_test.go
@@ -66,7 +66,6 @@ func TestBuilderSimple(t *testing.T) {
 	if err != nil {
 		t.Errorf("got error closing set builder: %v", err)
 	}
-	b.Reset(ioutil.Discard)
 }
 
 func TestBuilderSharedPrefix(t *testing.T) {
@@ -234,9 +233,6 @@ func loadWords(path string) ([]string, error) {
 var thousandTestWords []string
 
 func BenchmarkBuilder(b *testing.B) {
-	//fmt.Println(unsafe.Sizeof(builderNode{}))
-	// fmt.Println(unsafe.Sizeof(transition{}))
-	// panic("hmm")
 	dataset := thousandTestWords
 	randomThousandVals := randomValues(dataset)
 

--- a/registry.go
+++ b/registry.go
@@ -55,7 +55,6 @@ var entryCount = 0
 func (r *registry) entry(node *builderNode) (bool, int, *registryCell) {
 	entryCount++
 	if len(r.table) == 0 {
-		panic("bad")
 		return false, 0, nil
 	}
 	bucket := r.hash(node)

--- a/registry.go
+++ b/registry.go
@@ -47,7 +47,12 @@ func newRegistry(p *builderNodePool, tableSize, mruSize int) *registry {
 func (r *registry) Reset() {
 	var empty registryCell
 	for i := range r.table {
-		r.builderNodePool.Put(r.table[i].node)
+		if r.table[i].node != nil {
+			// Only try and return to the pool if the node actually exists to
+			// avoid excessive function call overhead in the scenario where many
+			// of the cells are empty.
+			r.builderNodePool.Put(r.table[i].node)
+		}
 		r.table[i] = empty
 	}
 }

--- a/registry.go
+++ b/registry.go
@@ -86,7 +86,7 @@ type registryCache []registryCell
 
 // The registry is responsible for returning BuilderNodes that it controls to the BuilderNodePool once
 // they are evicted. As a result, all the codepaths in the entry method that return false (entry was not
-// found and the registry is assuming ownership of this node) will return the corresponding evicted to to
+// found and the registry is assuming ownership of this node) will return the corresponding evicted node to
 // the builderNodePool.
 func (r registryCache) entry(node *builderNode, pool *builderNodePool) (bool, int, *registryCell) {
 	if len(r) == 1 {

--- a/registry.go
+++ b/registry.go
@@ -77,6 +77,10 @@ func (r *registry) hash(b *builderNode) int {
 
 type registryCache []registryCell
 
+// The registry is responsible for returning BuilderNodes that it controls to the BuilderNodePool once
+// they are evicted. As a result, all the codepaths in the entry method that return false (entry was not
+// found and the registry is assuming ownership of this node) will return the corresponding evicted to to
+// the builderNodePool.
 func (r registryCache) entry(node *builderNode, pool *builderNodePool) (bool, int, *registryCell) {
 	if len(r) == 1 {
 		if r[0].node != nil && r[0].node.equiv(node) {

--- a/registry.go
+++ b/registry.go
@@ -19,6 +19,13 @@ type registryCell struct {
 	node *builderNode
 }
 
+// Registry is used as a form of LRU so that the number of nodes that need to be kept
+// in memory is reduced. When the builder is compiling the FST and is presented with
+// compiling a given node, it can check the registry to see if an equivalent node has
+// already been compiled. If so, the registry will return the address of the already
+// compiled node and the builder can use that. If an equivalent node has not already
+// been compiled (or was, but has since been evicted from the LRU), the builder will
+// recompile it into the encoder and then add it to the registry for future use.
 type registry struct {
 	builderNodePool *builderNodePool
 	table           []registryCell

--- a/registry.go
+++ b/registry.go
@@ -37,23 +37,15 @@ func newRegistry(p *builderNodePool, tableSize, mruSize int) *registry {
 	return rv
 }
 
-var notEmptyCount = 0
-
 func (r *registry) Reset() {
 	var empty registryCell
 	for i := range r.table {
-		if r.table[i].node != nil {
-			notEmptyCount++
-		}
 		r.builderNodePool.Put(r.table[i].node)
 		r.table[i] = empty
 	}
 }
 
-var entryCount = 0
-
 func (r *registry) entry(node *builderNode) (bool, int, *registryCell) {
-	entryCount++
 	if len(r.table) == 0 {
 		return false, 0, nil
 	}
@@ -85,9 +77,6 @@ func (r *registry) hash(b *builderNode) int {
 
 type registryCache []registryCell
 
-var matchCount = 0
-var insertCount = 0
-
 func (r registryCache) entry(node *builderNode, pool *builderNodePool) (bool, int, *registryCell) {
 	if len(r) == 1 {
 		if r[0].node != nil && r[0].node.equiv(node) {
@@ -101,7 +90,6 @@ func (r registryCache) entry(node *builderNode, pool *builderNodePool) (bool, in
 		if r[i].node != nil && r[i].node.equiv(node) {
 			addr := r[i].addr
 			r.promote(i)
-			matchCount++
 			return true, addr, nil
 		}
 	}

--- a/vellum.go
+++ b/vellum.go
@@ -54,9 +54,10 @@ var ErrIteratorDone = errors.New("iterator-done")
 // BuilderOpts is a structure to let advanced users customize the behavior
 // of the builder and some aspects of the generated FST.
 type BuilderOpts struct {
-	Encoder           int
-	RegistryTableSize int
-	RegistryMRUSize   int
+	Encoder                  int
+	RegistryTableSize        int
+	RegistryMRUSize          int
+	BuilderNodePoolingConfig BuilderNodePoolingConfig
 }
 
 // New returns a new Builder which will stream out the

--- a/vellum_test.go
+++ b/vellum_test.go
@@ -151,9 +151,26 @@ func TestRoundTripSimple(t *testing.T) {
 }
 
 func TestRoundTripThousand(t *testing.T) {
-	dataset := thousandTestWords
-	randomThousandVals := randomValues(dataset)
+	b, err := New(nil, nil)
+	if err != nil {
+		t.Fatalf("error creating builder: %v", err)
+	}
 
+	testRoundTripThousand(t, b)
+}
+
+func TestRoundTripThousandBuilderIsReusable(t *testing.T) {
+	b, err := New(nil, nil)
+	if err != nil {
+		t.Fatalf("error creating builder: %v", err)
+	}
+
+	for i := 0; i < 1000; i++ {
+		testRoundTripThousand(t, b)
+	}
+}
+
+func testRoundTripThousand(t *testing.T, b *Builder) {
 	f, err := ioutil.TempFile("", "vellum")
 	if err != nil {
 		t.Fatal(err)
@@ -171,10 +188,10 @@ func TestRoundTripThousand(t *testing.T) {
 		}
 	}()
 
-	b, err := New(f, nil)
-	if err != nil {
-		t.Fatalf("error creating builder: %v", err)
-	}
+	b.Reset(f)
+
+	dataset := thousandTestWords
+	randomThousandVals := randomValues(dataset)
 
 	err = insertStrings(b, dataset, randomThousandVals)
 	if err != nil {

--- a/vellum_test.go
+++ b/vellum_test.go
@@ -188,7 +188,10 @@ func testRoundTripThousand(t *testing.T, b *Builder) {
 		}
 	}()
 
-	b.Reset(f)
+	err = b.Reset(f)
+	if err != nil {
+		t.Fatalf("error resetting builder: %v", err)
+	}
 
 	dataset := thousandTestWords
 	randomThousandVals := randomValues(dataset)


### PR DESCRIPTION
The existing implementation was missing a lot of places where BuilderNodes should be returned to the pool, which was causing the pool to leak massively and allocations would be very high when building FSTs. This addresses that issue, improves the comments / documentation, and also sets more reasonable default values for the pooling.

before
```
goos: darwin
goarch: amd64
pkg: github.com/m3db/vellum
BenchmarkBuilder-8           2000        649700 ns/op      269256 B/op        5832 allocs/op
PASS
ok      github.com/m3db/vellum    1.381s
Success: Benchmarks passed.
```

after
```
goos: darwin
goarch: amd64
pkg: github.com/m3db/vellum
BenchmarkBuilder-8   	    3000	    465007 ns/op	     737 B/op	       5 allocs/op
PASS
ok  	github.com/m3db/vellum	1.465s
Success: Benchmarks passed.
```